### PR TITLE
Echo Framework Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Heroku Buildpack libjq
+
+Heroku Buildpack [libjq](https://github.com/stedolan/jq/wiki/C-API:-libjq) allows for installing libraries that require it like [ruby-jq](https://github.com/winebarrel/ruby-jq) for example.
+
+## Usage
+
+This buildpack will need to be inserted into the list of buildpacks for your application. It is not intended to be a standalone buildpack that supports an application framework.
+
+```sh
+> heroku buildpacks:add -i 1 https://github.com/technekes/heroku-buildpack-libjq
+Buildpack added. Next release on tk-qa-incent-api will use:
+  1. https://github.com/technekes/heroku-buildpack-libjq
+  2. heroku/ruby
+Run git push heroku master to create a new release using these buildpacks.
+```

--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# Nothing to detect, just agree
+echo "jq"
 exit 0


### PR DESCRIPTION
The current version of the [buildpack documentation](https://devcenter.heroku.com/articles/buildpack-api#bin-detect-summary) states:

>  If the exit code is 0, the script must print a human-readable framework name to stdout.
